### PR TITLE
LTI-44 Remove old AppLaunches

### DIFF
--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -22,6 +22,13 @@ class AppsController < ApplicationController
     message = lti_launch.message
     message.custom_params['oauth_consumer_key'] = params[:oauth_consumer_key]
 
+    # FIX ME
+    # Move to a worker or cache the result
+    date_limit = Rails.configuration.launch_days_to_delete.days.ago
+    Rails.logger.info "Removing the old AppLaunches from before #{date_limit}"
+    deleted_launches = AppLaunch.where('created_at < ?', date_limit).delete_all
+    Rails.logger.info "#{deleted_launches} AppLaunches deleted"
+
     AppLaunch.find_or_create_by(nonce: lti_launch.nonce) do |launch|
       launch.update(tool_id: tool.id, message: message.to_json)
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,9 @@ module BbbLtiBroker
 
     config.launch_nonce_duration = (ENV['LAUNCH_NONCE_DURATION'] || 300).to_i.seconds
 
+    # Configures how many days AppLaunches will be kept on the db.
+    # AppLaunches that are more than {launch_days_to_delete} days old will be deleted
+    # every time app_launch is called.
     config.launch_days_to_delete = (ENV['LAUNCH_DAYS_TO_DELETE'] || 15).to_i
 
     config.app_name = ENV["APP_NAME"] || 'BbbLtiBroker'

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,7 +25,7 @@ module BbbLtiBroker
 
     config.launch_nonce_duration = (ENV['LAUNCH_NONCE_DURATION'] || 300).to_i.seconds
 
-    config.launch_days_to_delete = ENV['LAUNCH_DAYS_TO_DELETE'].to_i
+    config.launch_days_to_delete = (ENV['LAUNCH_DAYS_TO_DELETE'] || 15).to_i
 
     config.app_name = ENV["APP_NAME"] || 'BbbLtiBroker'
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,8 @@ module BbbLtiBroker
 
     config.launch_nonce_duration = (ENV['LAUNCH_NONCE_DURATION'] || 300).to_i.seconds
 
+    config.launch_days_to_delete = ENV['LAUNCH_DAYS_TO_DELETE'].to_i
+
     config.app_name = ENV["APP_NAME"] || 'BbbLtiBroker'
 
     # use a json formatter to match lograge's logs


### PR DESCRIPTION
The env variable **LAUNCH_DAYS_TO_DELETE** will determine the lifetime of the AppLaunch on the db.

Don't forget to add it to the .env file.