### PR TITLE
LTI-45 - Fix remove old app launches

### DIFF
--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -25,9 +25,12 @@ class AppsController < ApplicationController
     # FIX ME
     # Move to a worker or cache the result
     date_limit = Rails.configuration.launch_days_to_delete.days.ago.utc
-    Rails.logger.info "Removing the old AppLaunches from before #{date_limit}"
+    query_started = Time.now.utc
     deleted_launches = AppLaunch.where('expiration_time < ?', date_limit).delete_all
-    Rails.logger.info "#{deleted_launches} AppLaunches deleted"
+    query_duration = Time.now.utc - query_started
+    Rails.logger.info "Removing the old AppLaunches from before #{date_limit}, " \
+                      "#{deleted_launches} AppLaunches deleted, " \
+                      "in: #{query_duration.round(3)} seconds"
 
     AppLaunch.find_or_create_by(nonce: lti_launch.nonce) do |launch|
       launch.update(tool_id: tool.id, message: message.to_json)

--- a/db/migrate/20210714202041_add_index_on_app_launches_expiration_time.rb
+++ b/db/migrate/20210714202041_add_index_on_app_launches_expiration_time.rb
@@ -1,0 +1,5 @@
+class AddIndexOnAppLaunchesExpirationTime < ActiveRecord::Migration[6.0]
+  def change
+    add_index(:app_launches, :expiration_time)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_19_012138) do
+ActiveRecord::Schema.define(version: 2021_07_14_202041) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2020_07_19_012138) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "expiration_time"
+    t.index ["expiration_time"], name: "index_app_launches_on_expiration_time"
     t.index ["nonce"], name: "index_app_launches_on_nonce"
   end
 


### PR DESCRIPTION
The logger lines were transformed into just one for easy viewing;
Added index on expiration_time field, used to delete old app_launches