### PR TITLE
LTI-84 - Add and configure prometheus_exporter and add container for prod service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,10 @@ gem 'rails_lti2_provider', git: 'https://github.com/mconf/rails_lti2_provider.gi
 
 gem 'rails_admin', '~> 2.0'
 
+group :production do
+  gem 'prometheus_exporter'
+end
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,8 @@ GEM
     parser (2.7.1.3)
       ast (~> 2.4.0)
     pg (1.2.3)
+    prometheus_exporter (1.0.1)
+      webrick
     public_suffix (4.0.5)
     puma (4.3.5)
       nio4r (~> 2.0)
@@ -359,6 +361,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    webrick (1.7.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -388,6 +391,7 @@ DEPENDENCIES
   oauth (~> 0.5.1)
   oauthenticator
   pg (>= 0.4.4)
+  prometheus_exporter
   puma (>= 4.3.5)
   rails (~> 6.0.3)
   rails_admin (~> 2.0)
@@ -395,7 +399,7 @@ DEPENDENCIES
   react-rails
   resque
   resque-scheduler
-  rest-client (> 2)
+  rest-client (>= 2)
   rubocop (~> 0.79.0)
   rubocop-rails (~> 2.4.0)
   sass-rails (>= 6)

--- a/config/application.rb
+++ b/config/application.rb
@@ -56,5 +56,12 @@ module BbbLtiBroker
     config.redis_port      = ENV['MCONF_REDIS_PORT']
     config.redis_db        = ENV['MCONF_REDIS_DB']
     config.redis_password  = ENV['MCONF_REDIS_PASSWORD']
+
+    # Prevent errors when precompiling assets in local production
+    if ENV['RAILS_ENV'] == 'development'
+      config.assets.configure do |env|
+        env.export_concurrent = false
+      end
+    end
   end
 end

--- a/config/initializers/prometheus_exporter.rb
+++ b/config/initializers/prometheus_exporter.rb
@@ -1,0 +1,6 @@
+if Rails.env.production?
+  require 'prometheus_exporter/middleware'
+
+  # This reports stats per request like HTTP status and timings
+  Rails.application.middleware.unshift PrometheusExporter::Middleware
+end

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -16,10 +16,7 @@ attrs = {
 attrs[:password] = Rails.application.config.redis_password unless Rails.application.config.redis_password.blank?
 Resque.redis = Redis.new(attrs)
 
-# Scheduler configuration
-yml_schedule     = YAML.load_file("config/jobs_schedule.yml")
-wrapped_schedule = ActiveScheduler::ResqueWrapper.wrap yml_schedule
-Resque.schedule  = wrapped_schedule
+# NOTE: the scheduler is configured on lib/tasks/resque.rake
 
 # Authentication for the Resque web interface
 Resque::Server.use(Rack::Auth::Basic) do |user, password|

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -48,6 +48,16 @@ on_worker_boot do
   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
 end
 
+# Initialize prometheus_exporter
+# This will only work in clustered mode, so if PUMA_WORKERS is not set it won't
+# work (setting PUMA_WORKERS=1 works)
+after_worker_boot do
+  if Rails.env.production?
+    require 'prometheus_exporter/instrumentation'
+    PrometheusExporter::Instrumentation::Puma.start
+  end
+end
+
 # Allow puma to be restarted by `rails restart` command.
 plugin(:tmp_restart)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,48 @@ services:
     ports:
       - "5432:5432"
 
+  prod:
+    container_name: broker_app_prod
+    image: broker_app_prod:prod
+    build:
+      context: .
+      args:
+        RAILS_ENV: production
+    env_file:
+      - ./.env
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql://postgres:password@postgres:5432/lti_broker}
+      RAILS_ENV: production
+      MCONF_REDIS_HOST: broker_redis
+      MCONF_REDIS_PASSWORD: BCsy8zMwZay669ii
+      MCONF_REDIS_PORT: 6379
+      MCONF_REDIS_DB: 0
+      PROMETHEUS_EXPORTER_HOST: prod_exporter
+      PROMETHEUS_EXPORTER_PORT: 9394
+      PUMA_WORKERS: 1
+    volumes:
+      - .:/usr/src/app
+    ports:
+      - "3000:3000"
+    links:
+      - postgres
+    depends_on:
+      - broker_redis
+      - prod_exporter
+
+  prod_exporter:
+    container_name: broker_prod_exporter
+    image: broker_app_prod:prod
+    tty: true
+    stdin_open: true
+    ports:
+      - "9394:9394"
+    env_file:
+      - ./.env
+    volumes:
+      - .:/usr/src/app
+    command: bundle exec prometheus_exporter -b 0.0.0.0 -p 9394 --prefix 'broker_app_'
+
   broker_redis:
     container_name: broker_dev_redis
     image: redis:3.2

--- a/lib/tasks/resque.rake
+++ b/lib/tasks/resque.rake
@@ -17,5 +17,10 @@ namespace :resque do
     # schedule changes and applies them on the fly.
     # Note: This feature is only available in >=2.0.0.
     # Resque::Scheduler.dynamic = true
+
+    # Scheduler configuration
+    yml_schedule     = YAML.load_file("config/jobs_schedule.yml")
+    wrapped_schedule = ActiveScheduler::ResqueWrapper.wrap yml_schedule
+    Resque.schedule  = wrapped_schedule
   end
 end


### PR DESCRIPTION
Add a container for the prod service: `docker-compose up prod`, to simulate the local environment.

Add a container: `prod_exporter`, to export metrics with prometheus in production environment.

"[prometheus_exporter](https://github.com/discourse/prometheus_exporter) is a gem that collects information from a Rails application and exposes them in a format that prometheus can read."