### PR TITLE
[LTI-105] Add origin URL to COC app_launches

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -399,7 +399,7 @@ DEPENDENCIES
   react-rails
   resque
   resque-scheduler
-  rest-client (~> 2)
+  rest-client (>= 2)
   rubocop (~> 0.79.0)
   rubocop-rails (~> 2.4.0)
   sass-rails (>= 6)

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,8 +41,9 @@ module BbbLtiBroker
     config.coc_client_secret = ENV['COC_CLIENT_SECRET']
     config.coc_consumer_key = ENV['COC_CONSUMER_KEY']
     config.coc_consumer_secret = ENV['COC_CONSUMER_SECRET']
-    config.coc_portal_host = ENV['COC_PASSAPORTE_URI']
+    config.coc_portal_host = ENV['COC_PORTAL_HOST']
     config.coc_package_id = ENV['COC_PACKAGE_ID']
+    config.coc_passaporte_host = ENV['COC_PASSAPORTE_URI']
 
     # use a json formatter to match lograge's logs
     if ENV['LOGRAGE_ENABLED'] == '1'

--- a/lib/clients/coc/api/request.rb
+++ b/lib/clients/coc/api/request.rb
@@ -93,7 +93,7 @@ module Clients::Coc
       def build_url(path, query = {})
         URI::HTTPS.build(
           scheme: 'https',
-          host: Rails.application.config.coc_portal_host,
+          host: Rails.application.config.coc_passaporte_host,
           path: path,
           query: URI.encode_www_form(query)
         ).to_s

--- a/lib/clients/coc/controllers/auth_controller.rb
+++ b/lib/clients/coc/controllers/auth_controller.rb
@@ -77,6 +77,7 @@ module Clients::Coc
               'schools' => user_data.schools,
             },
             'roles' => user_data.roles,
+            'lis_outcome_service_url' => 'https://' + Rails.application.config.coc_portal_host
           }
         message.merge!(adapted_user_params(user_data))
       end


### PR DESCRIPTION
The URL comes from the new `COC_PORTAL_HOST` env variable.
It will be used by Rooms app to return the `consumer_domain` and later by Reports app to identify meetings created via COC portal, allowing reports generation for them.