### PR TITLE
[PRT-2174] Expire Redis cache_store keys on production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -139,19 +139,22 @@ Rails.application.configure do
   end
 
   config.cache_store = if ENV['REDIS_URL'].present?
-                         # Set up Redis cache store
-                         [:redis_cache_store, { url: ENV['REDIS_URL'],
-
-                                                connect_timeout: 30, # Defaults to 20 seconds
-                                                read_timeout: 0.2, # Defaults to 1 second
-                                                write_timeout: 0.2, # Defaults to 1 second
-                                                reconnect_attempts: 1, # Defaults to 0
-
-                                                error_handler: lambda { |method:, returning:, exception:|
-                                                                 Rails.logger.warn("Support: Redis cache action #{method} failed and returned '#{returning}': #{exception}")
-                                                               }, },]
+                        # Set up Redis cache store
+                        [:redis_cache_store,
+                          {
+                            url: ENV['REDIS_URL'],
+                            expires_in: 1.day,
+                            connect_timeout: 30, # Defaults to 20 seconds
+                            read_timeout: 0.2, # Defaults to 1 second
+                            write_timeout: 0.2, # Defaults to 1 second
+                            reconnect_attempts: 1, # Defaults to 0
+                            error_handler: lambda { |method:, returning:, exception:|
+                                              Rails.logger.warn("Support: Redis cache action #{method} failed and returned '#{returning}': #{exception}")
+                                            }
+                          }
+                        ]
                        else
-                         [:file_store, Rails.root.join('tmp/cache_store')]
+                          [:file_store, Rails.root.join('tmp/cache_store')]
                        end
 
   config.hosts = ENV['WHITELIST_HOST'].presence || nil


### PR DESCRIPTION
Set `expires_in` to 1 day.