### PR TITLE
[PRT-2147] LTI 1.0 tool registration via URL

### DIFF
--- a/app/controllers/message_controller.rb
+++ b/app/controllers/message_controller.rb
@@ -113,7 +113,7 @@ class MessageController < ApplicationController
     return if params[:app] == 'default'
 
     params[:oauth_nonce] = @jwt_body['nonce']
-    params[:oauth_consumer_key] = @jwt_body['iss']
+    params[:oauth_consumer_key] = @jwt_body['aud']
     Rails.cache.write(params[:oauth_nonce], message: @message, oauth: { consumer_key: params[:oauth_consumer_key], timestamp: @jwt_body['exp'] })
     @lti_launch.update(user_id: @current_user.id)
 

--- a/app/controllers/tool_profile_controller.rb
+++ b/app/controllers/tool_profile_controller.rb
@@ -80,9 +80,7 @@ class ToolProfileController < ApplicationController
   end
 
   def xml_config
-    render(xml: xml_config_tc(
-      blti_launch_url(app: params[:app]).sub('https', 'http')
-    ))
+    render(xml: xml_config_tc(blti_launch_url(app: params[:app])))
   end
 
   # This action is used only to support the old bbb application for backward compatibility
@@ -117,8 +115,8 @@ class ToolProfileController < ApplicationController
   end
 
   def xml_config_tc(launch_url)
-    title = t("apps.#{params[:app]}.title", default: "#{params[:app].capitalize} #{t('apps.default.title')}")
-    description = t("apps.#{params[:app]}.description", default: "#{t('apps.default.title')} provider powered by BBB LTI Broker.")
+    title = ENV["TOOL_#{params[:app].upcase}_TITLE"] || t("apps.#{params[:app]}.title", default: "#{params[:app].capitalize} #{t('apps.default.title')}")
+    description = ENV["TOOL_#{params[:app].upcase}_DESCRIPTION"] || t("apps.#{params[:app]}.description", default: "#{t('apps.default.title')} provider powered by BBB LTI Broker.")
     tc = IMS::LTI::Services::ToolConfig.new(title: title, launch_url: launch_url) # "#{location}/#{year}/#{id}"
     tc.secure_launch_url = secure_url(tc.launch_url)
     tc.icon = lti_icon(params[:app])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,8 +95,8 @@ Rails.application.routes.draw do
     match ':app/json_config/:temp_key_token', to: 'tool_profile#json_config', via: [:get, :post], as: 'json_config' # , :defaults => {:format => 'json'}
 
     # xml config and builder for lti 1.0/1.1
-    get ':app/xml_config', to: 'tool_profile#xml_config', app: Rails.configuration.default_tool, as: :xml_config
-    get ':app/xml_builder', to: 'tool_profile#xml_builder', app: Rails.configuration.default_tool, as: :xml_builder
+    get ':app/xml_config', to: 'tool_profile#xml_config', as: :xml_config
+    get ':app/xml_builder', to: 'tool_profile#xml_builder', as: :xml_builder
     # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
     get '/errors/:code', to: 'errors#index', as: :errors

--- a/dotenv
+++ b/dotenv
@@ -14,7 +14,8 @@ RELATIVE_URL_ROOT=lti
 DEFAULT_LTI_TOOL=tool
 # To use a different url for icons (useful when using a CDN, for example)
 # TOOL_ROOMS_ICON=https://ks872jadt5c9a8.cloudfront.net/rooms/assets/favicon.ico
-# TOOL_GRADES_ICON=https://ks872jadt5c9a8.cloudfront.net/grades/assets/favicon.ico
+# TOOL_ROOMS_TITLE=Rooms DEV
+# TOOL_ROOMS_DESCRIPTION=Rooms App DEV
 
 # Consumer key
 CONSUMER_KEY=key

--- a/lib/bbb_lti_broker/helpers.rb
+++ b/lib/bbb_lti_broker/helpers.rb
@@ -45,6 +45,7 @@ module BbbLtiBroker
     end
 
     def secure_url(url)
+      return nil if url.nil?
       uri = URI.parse(url)
       uri.scheme = 'https'
       uri.to_s


### PR DESCRIPTION
To allow apps with different themes to set their own info. The icon already used this approach.
Now the env vars are:
- `TOOL_ROOMS_ICON`
- `TOOL_ROOMS_TITLE`
- `TOOL_ROOMS_DESCRIPTION`