### PR TITLE
[PRT-2551] fix: require https for moodle urls

### DIFF
--- a/app/models/rooms_app_config.rb
+++ b/app/models/rooms_app_config.rb
@@ -1,6 +1,10 @@
 class RoomsAppConfig < ApplicationRecord
   belongs_to :tool, class_name: 'RailsLti2Provider::Tool'
 
+  validates :moodle_url,
+            format: { with: /\Ahttps:\/\//i, message: 'permite apenas URLs que começam com https://' },
+            allow_blank: true
+
   def attributes_for_launch
     self.attributes.except('id', 'created_at', 'updated_at', 'tool_id').compact
   end

--- a/app/models/rooms_app_config.rb
+++ b/app/models/rooms_app_config.rb
@@ -26,4 +26,13 @@ class RoomsAppConfig < ApplicationRecord
     .select{ |key, _| key.start_with?('brightspace_') }
     .transform_keys { |key| key.delete_prefix('brightspace_') }
   end
+
+  after_save :log_moodle_url_update, if: :saved_change_to_moodle_url?
+
+  private
+
+  def log_moodle_url_update
+    Rails.logger.info("[Security] moodle_url updated: #{moodle_url}")
+  end
+
 end

--- a/app/models/rooms_app_config.rb
+++ b/app/models/rooms_app_config.rb
@@ -2,7 +2,15 @@ class RoomsAppConfig < ApplicationRecord
   belongs_to :tool, class_name: 'RailsLti2Provider::Tool'
 
   validates :moodle_url,
-            format: { with: /\Ahttps:\/\//i, message: 'permite apenas URLs que começam com https://' },
+            format: {
+              with: /\Ahttps:\/\//i,
+              message: ->(_object, _data) {
+                I18n.t(
+                  'errors.messages.rooms_app_config.moodle_url_https_only',
+                  default: 'permite apenas URLs que começam com https://'
+                )
+              }
+            },
             allow_blank: true
 
   def attributes_for_launch

--- a/app/models/rooms_app_config.rb
+++ b/app/models/rooms_app_config.rb
@@ -44,7 +44,22 @@ class RoomsAppConfig < ApplicationRecord
   private
 
   def log_moodle_url_update
-    Rails.logger.info("[Security] moodle_url updated: #{moodle_url}")
+    old_url, new_url = saved_change_to_moodle_url
+
+    Rails.logger.info(
+      "[Security] moodle_url updated from #{sanitize_moodle_url(old_url)} to #{sanitize_moodle_url(new_url)}"
+    )
+  end
+
+  def sanitize_moodle_url(url)
+    return 'blank' if url.blank?
+
+    uri = URI.parse(url)
+    sanitized = "#{uri.scheme}://#{uri.host}"
+    sanitized += ":#{uri.port}" if uri.port && ![80, 443].include?(uri.port)
+    sanitized
+  rescue URI::InvalidURIError
+    url.to_s.sub(%r{\?.*}, '').sub(%r{#.*}, '')
   end
 
 end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -105,6 +105,9 @@ RailsAdmin.config do |config|
         end
         field :moodle_url do
           label 'API URL'
+          html_attributes do
+            { pattern: 'https://.*', title: 'O campo deve começar com https://' }
+          end
         end
         field :moodle_token do
           label 'API Token'

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -106,7 +106,7 @@ RailsAdmin.config do |config|
         field :moodle_url do
           label 'API URL'
           html_attributes do
-            { pattern: 'https://.*', title: 'O campo deve começar com https://' }
+            { pattern: '[Hh][Tt][Tt][Pp][Ss]://.*', title: 'O campo deve começar com https://' }
           end
         end
         field :moodle_token do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -111,6 +111,9 @@ en:
         code: "ServerError"
         message: "Server error"
         suggestion: "Please try again later or contact an administrator."
+  messages:
+    rooms_app_config:
+      moodle_url_https_only: "only allows URLs that start with https://"
   tool:
     app_settings: "App settings"
     created_at: "Created at"


### PR DESCRIPTION
This PR ensures only HTTPS URLs are accepted for moodle_url. It also introduces an audit trail to track changes to this sensitive field, preventing the silent integration failures caused by HTTP redirects.

**Changes:**
Audit Log (chore): Added an after_save callback to log any changes to moodle_url with a [Security] tag. This allows for monitoring and historical tracking of endpoint updates.

Validation (feat): Implemented a protocol validation that blocks http:// entries, forcing the use of https:// at the model level.

UX/UI Improvement: Added a pattern to the moodle_url field with a visual alert to prevent users from attempting to save or update a HTTP URL.

**Visual Changes:**
- Visual alert on Rooms_app_config (moodle_url field):
<img width="523" height="119" alt="Captura de tela de 2026-04-15 20-05-37" src="https://github.com/user-attachments/assets/cd75e502-6ca4-4f44-901b-d824b95b2c8e" />

- Visual Alert from the validations changes:
<img width="1564" height="96" alt="Captura de tela de 2026-04-15 19-29-46" src="https://github.com/user-attachments/assets/a52eb573-b3e1-444e-8841-f6f8a48cc6ca" />
