### PR TITLE
[PRT-2473] AI Artifacts on Demand: add `allow_ai_artifacts` flag

### DIFF
--- a/db/migrate/20260615120000_add_allow_ai_artifacts_to_rooms_app_configs.rb
+++ b/db/migrate/20260615120000_add_allow_ai_artifacts_to_rooms_app_configs.rb
@@ -1,0 +1,5 @@
+class AddAllowAiArtifactsToRoomsAppConfigs < ActiveRecord::Migration[8.0]
+  def change
+    add_column :rooms_app_configs, :allow_ai_artifacts, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_25_161610) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_15_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -155,6 +155,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_25_161610) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "allow_student_scheduling", default: false, null: false
+    t.boolean "allow_ai_artifacts", default: true, null: false
     t.index ["tool_id"], name: "index_rooms_app_configs_on_tool_id"
   end
 


### PR DESCRIPTION
## Per-consumer feature flag
- Adds `allow_ai_artifacts` to Consumer Config's **RoomsAppConfig**;
- When `false`, the AI artifacts dropdown  (in the Rooms application) will be entirely hidden; defaults to `true` so existing consumers are unaffected.