### PR TITLE
[PRT-2605] Add Moodle integration support to EduplayAppConfig

### DIFF
--- a/app/models/eduplay_app_config.rb
+++ b/app/models/eduplay_app_config.rb
@@ -1,7 +1,33 @@
 class EduplayAppConfig < ApplicationRecord
   belongs_to :tool, class_name: 'RailsLti2Provider::Tool'
 
+  validates :moodle_url,
+            format: {
+              with: /\Ahttps:\/\//i,
+              message: ->(_object, _data) {
+                I18n.t(
+                  'errors.messages.eduplay_app_config.moodle_url_https_only',
+                  default: 'permite apenas URLs que começam com https://'
+                )
+              }
+            },
+            allow_blank: true
+
   def attributes_for_launch
     self.attributes.except('id', 'created_at', 'updated_at', 'tool_id').compact
+  end
+
+  def eduplay_configs
+    self.attributes_for_launch.reject do |key, _|
+      key.start_with?('moodle_')
+    end
+  end
+
+  def moodle_configs
+    return nil unless self.moodle_integration_enabled?
+
+    self.attributes_for_launch.except('moodle_integration_enabled')
+    .select{ |key, _| key.start_with?('moodle_') }
+    .transform_keys { |key| key.delete_prefix('moodle_') }
   end
 end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -197,6 +197,32 @@ RailsAdmin.config do |config|
       configure :tool do
         hide
       end
+
+      include_all_fields
+      group :default do
+      end
+
+      # Moodle Configs
+      group :moodle_configs do
+        active false
+
+        field :moodle_integration_enabled do
+          label 'Moodle integration enabled'
+          help 'If disabled, the Moodle configs are not sent. The MoodleToken is destroyed in Eduplay database.'
+        end
+        field :moodle_url do
+          label 'API URL'
+        end
+        field :moodle_token do
+          label 'API Token'
+        end
+        field :moodle_group_select_enabled do
+          label 'Group select enabled'
+        end
+        field :moodle_show_all_groups do
+          label 'Show all groups'
+        end
+      end
     end
   end
   ### EduplayAppConfig ###

--- a/config/initializers/rails_lti2_provider.rb
+++ b/config/initializers/rails_lti2_provider.rb
@@ -41,7 +41,8 @@ Rails.application.config.to_prepare do
     # Prepare configs to be sent as custom_params on Eduplay app launch
     def eduplay_app_configs_for_launch
       configs = {}
-      configs.merge!(self.eduplay_app_config&.attributes_for_launch || {})
+      configs.merge!(self.eduplay_app_config&.eduplay_configs || {})
+      configs['moodle'] = self.eduplay_app_config&.moodle_configs
 
       configs.compact
     end

--- a/db/migrate/20260331181216_add_moodle_integration_to_eduplay_app_configs.rb
+++ b/db/migrate/20260331181216_add_moodle_integration_to_eduplay_app_configs.rb
@@ -1,0 +1,9 @@
+class AddMoodleIntegrationToEduplayAppConfigs < ActiveRecord::Migration[8.0]
+  def change
+    add_column :eduplay_app_configs, :moodle_integration_enabled, :boolean, default: false, null: false
+    add_column :eduplay_app_configs, :moodle_url, :string
+    add_column :eduplay_app_configs, :moodle_token, :string
+    add_column :eduplay_app_configs, :moodle_group_select_enabled, :boolean, default: false, null: false
+    add_column :eduplay_app_configs, :moodle_show_all_groups, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_25_161610) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_31_181216) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -33,6 +33,11 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_25_161610) do
     t.string "eduplay_password"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "moodle_integration_enabled", default: false, null: false
+    t.string "moodle_url"
+    t.string "moodle_token"
+    t.boolean "moodle_group_select_enabled", default: false, null: false
+    t.boolean "moodle_show_all_groups", default: false, null: false
     t.index ["tool_id"], name: "index_eduplay_app_configs_on_tool_id"
   end
 


### PR DESCRIPTION
This pull request introduces support for Moodle integration in the Eduplay app configuration. It adds new database fields and model methods to manage Moodle-related settings, updates the admin interface to handle these configs, and adjusts how configuration data is prepared for launches.

**Moodle Integration Support**

* Added new fields to the `eduplay_app_configs` table for Moodle integration, including `moodle_integration_enabled`, `moodle_url`, `moodle_token`, `moodle_group_select_enabled`, and `moodle_show_all_groups`. [[1]](diffhunk://#diff-105bc827db275d56ab192e25282ca9dc2c4468147ce463b29ecde1621d07809aR1-R9) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R36-R40) [[3]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R13)
* Updated the `EduplayAppConfig` model to:
  * Validate that `moodle_url` starts with `https://`.
  * Add methods `eduplay_configs` and `moodle_configs` to separate general and Moodle-specific configs.

**Admin Interface Enhancements**

* Modified the RailsAdmin initializer to group and label Moodle-related fields, making them easier to manage in the admin UI.

**Config Preparation Logic**

* Updated the logic for preparing launch configs so that Moodle-specific settings are grouped under a `moodle` key and only included if enabled.