### PR TITLE
[PRT-2550] feat: add hide_recordings_history to broker's rooms_app_configs

### DIFF
--- a/db/migrate/20260706115418_add_hide_recordings_history_to_rooms_app_configs.rb
+++ b/db/migrate/20260706115418_add_hide_recordings_history_to_rooms_app_configs.rb
@@ -1,0 +1,6 @@
+class AddHideRecordingsHistoryToRoomsAppConfigs < ActiveRecord::Migration[8.0]
+  def change
+    add_column :rooms_app_configs, :hide_recordings_history, :boolean, default: false, null: false
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_31_181216) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_06_115418) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -160,6 +160,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_31_181216) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "allow_student_scheduling", default: false, null: false
+    t.boolean "hide_recordings_history", default: false, null: false
     t.index ["tool_id"], name: "index_rooms_app_configs_on_tool_id"
   end
 


### PR DESCRIPTION
This PR adds a new boolean flag `hide_recordings_history` to `rooms_app_configs` with default `false`. The flag is automatically available in the broker's admin interface (Rails Admin) and is sent to Rooms on launch via `rooms_configs`.
