### PR TITLE
[PRT-2503] Fix 500 errors in dash search filters and export

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -1,5 +1,49 @@
 # frozen_string_literal: true
 
+# RailsAdmin's built-in :json/:jsonb/:serialized field types blindly JSON.parse (or
+# yaml_load) the raw global-search query string for every field of that type, before
+# even checking whether it could match anything. That crashes the dashboard search
+# (500) whenever the query text isn't valid JSON/YAML (plain words, or e.g. "@"), and
+# the same call happens again for per-column filter submissions.
+#
+# These subclasses replace the registered field types for those three type keys, so
+# the fix applies automatically to every current AND future json/jsonb/serialized
+# column across the whole dash - no per-field config needed. Rather than trying to
+# make search/filter tolerate arbitrary text being parsed as JSON/YAML (which turned
+# out to have more failure modes than expected - deeply-nested input, invalid
+# encoding, non-String params - and, once made to work, risked exposing columns that
+# are hidden for good reason), these fields are simply excluded from search and
+# filtering entirely: #queryable (governs the global search box) and #searchable
+# (governs the per-column filter widgets, via #filterable?) are both hardcoded to
+# false, so #parse_value is never called on them by search/filter code at all.
+# `(*)` absorbs the setter form's argument instead of raising, without acting on it -
+# these fields are never searchable, so there's nothing to configure otherwise.
+# #parse_value/#parse_input are left untouched (the base classes' own, so the save
+# path - editing these fields through the dash's forms - keeps its original,
+# unmodified behavior).
+class SafeJsonField < RailsAdmin::Config::Fields::Types::Json
+  def queryable(*)
+    false
+  end
+
+  def searchable(*)
+    false
+  end
+end
+RailsAdmin::Config::Fields::Types.register(:json, SafeJsonField)
+RailsAdmin::Config::Fields::Types.register(:jsonb, SafeJsonField)
+
+class SafeSerializedField < RailsAdmin::Config::Fields::Types::Serialized
+  def queryable(*)
+    false
+  end
+
+  def searchable(*)
+    false
+  end
+end
+RailsAdmin::Config::Fields::Types.register(:serialized, SafeSerializedField)
+
 RailsAdmin.config do |config|
   config.main_app_name = 'Broker'
 

--- a/config/initializers/rails_lti2_provider.rb
+++ b/config/initializers/rails_lti2_provider.rb
@@ -48,4 +48,22 @@ Rails.application.config.to_prepare do
     end
   end
 
+  RailsLti2Provider::LtiLaunch.class_eval do
+    # Serialization (to_json/to_xml, e.g. via a dash export that includes
+    # associated lti_launches) reads attributes through #send by default, which
+    # for :message calls the overridden #message reader above - IMS::LTI::Models::
+    # Messages::Message.generate(self[:message]) - not the raw stored value. Some
+    # legacy launches have a double-JSON-encoded message (self[:message] is a
+    # String, not the expected Hash), which makes .generate raise NoMethodError:
+    # undefined method 'key?' for an instance of String, crashing serialization for
+    # the whole batch rather than just that one record. Reading the raw attribute
+    # here instead is both safe (never triggers that parse) and more useful for an
+    # export anyway - the raw stored params, not the wrapper object.
+    def read_attribute_for_serialization(key)
+      return self[:message] if key.to_s == 'message'
+
+      super
+    end
+  end
+
 end


### PR DESCRIPTION
## Summary

- **Dash search & filters**: RailsAdmin's built-in `:json`/`:jsonb`/`:serialized` field types blindly parsed the raw search/filter query text as JSON/YAML before checking for a match, crashing (500) whenever the query wasn't valid JSON/YAML (letters, symbols like `!`/`@`) - matching what was reported for Tool/Tenant searches and LTI launch searches. Registers safe field-type replacements that exclude these columns from the global search box and per-column filters entirely, so parsing is never attempted on arbitrary user input. Applies automatically to every current and future json/jsonb/serialized column across the dash, not just the ones originally reported.
- **Dash export**: some legacy `LtiLaunch` records have a double-JSON-encoded `message` column, which made the model's `#message` reader raise `NoMethodError` during serialization - crashing an export whenever it included associated `lti_launches` (e.g. exporting a `Tool` with launches included), matching the reported "export to json" 500 for Tools/Launch. Reads the raw stored attribute for serialization instead of going through that reader.
